### PR TITLE
Fix new labels without ideas always appearing first

### DIFF
--- a/app/add-label.tsx
+++ b/app/add-label.tsx
@@ -42,7 +42,7 @@ const AddLabel = () => {
       id: uuidv4(),
       text: labelText,
       createdAt: new Date().toISOString(),
-      lastUsedAt: new Date().toDateString(),
+      lastUsedAt: null,
       color,
       icon,
     }

--- a/db/queries/select.ts
+++ b/db/queries/select.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/client'
 import { IdeasByDateAndLabel } from '@/shared/types'
-import { and, desc, eq } from 'drizzle-orm'
+import { and, desc, eq, sql } from 'drizzle-orm'
 
 import { IdeasTable, LabelsTable } from '../schema'
 
@@ -18,14 +18,17 @@ const labelById = async (id: string) => {
 
 const labels = async (options?: { includeArchived?: boolean }) => {
   const query = db.select().from(LabelsTable)
+  // Use lastUsedAt if available, otherwise fall back to createdAt for sorting
+  // This ensures new labels without ideas are sorted by creation date
+  const sortColumn = sql`COALESCE(${LabelsTable.lastUsedAt}, ${LabelsTable.createdAt})`
 
   if (!options?.includeArchived) {
     return await query
       .where(eq(LabelsTable.isArchived, 0))
-      .orderBy(desc(LabelsTable.lastUsedAt))
+      .orderBy(desc(sortColumn))
   }
 
-  return await query.orderBy(desc(LabelsTable.lastUsedAt))
+  return await query.orderBy(desc(sortColumn))
 }
 
 const ideasGroupedByLabel = async (options?: { includeArchived?: boolean }) => {


### PR DESCRIPTION
## Summary

Fixes a bug where newly created labels with no ideas always appeared at the top of the label list.

**Root Cause:** When a label was created, `lastUsedAt` was initialized to today's date (`new Date().toDateString()`), causing it to sort to the top since labels are ordered by `lastUsedAt` descending.

## Changes

1. **Set `lastUsedAt` to `null` when creating a new label**
   - Labels without ideas now have `lastUsedAt = null`
   - This indicates the label has never been used for an idea

2. **Update sorting query to use `COALESCE(lastUsedAt, createdAt)`**
   - Labels with ideas: sorted by `lastUsedAt` (when last idea was added)
   - Labels without ideas: sorted by `createdAt` (when label was created)

## Result

New labels without ideas will now be sorted by their creation date rather than always appearing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)