### PR TITLE
Fix eas.json autoIncrement to be boolean

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -23,7 +23,7 @@
     },
     "testflight": {
       "distribution": "store",
-      "autoIncrement": "buildNumber",
+      "autoIncrement": true,
       "env": {
         "EXPO_BUNDLE_IDENTIFIER": "com.sillysideprojects.ideas.prod",
         "EXPO_APP_NAME": "Ideas Down",
@@ -32,7 +32,7 @@
     },
     "production": {
       "distribution": "store",
-      "autoIncrement": "buildNumber",
+      "autoIncrement": true,
       "env": {
         "EXPO_BUNDLE_IDENTIFIER": "com.sillysideprojects.ideas.prod",
         "EXPO_APP_NAME": "Ideas Down",


### PR DESCRIPTION
## Summary
- Change `autoIncrement` from `"buildNumber"` string to `true` boolean
- EAS now requires this to be a boolean value

🤖 Generated with [Claude Code](https://claude.com/claude-code)