### PR TITLE
Add margin to Show Archived toggle, bump version, fix changelog

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -84,7 +84,9 @@ const LabelSelect = () => {
             Ideas are grouped by Category
           </Typography>
           {hasArchivedLabels && (
-            <View style={styles.toggleContainer}>
+            <View
+              style={[styles.toggleContainer, { marginTop: SPACING.LARGE }]}
+            >
               <Text style={styles.toggleLabel}>Show Archived</Text>
               <Switch
                 value={showArchived}

--- a/shared/changelog.ts
+++ b/shared/changelog.ts
@@ -4,17 +4,17 @@ export type ChangelogEntry = {
   changes: string[]
 }
 
-export const CURRENT_VERSION = '1.4.3'
+export const CURRENT_VERSION = '1.4.4'
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
-    version: '1.4.3',
+    version: '1.4.4',
     date: '2026-01-24',
     changes: [
-      'Added ability to archive labels',
+      'Added ability to archive categories',
       'Added changelog modal for new version notifications',
       'Improved Reflect page performance with virtual scrolling',
-      'Fixed new labels without ideas always appearing first',
+      'Fixed new categories without ideas always appearing first',
       'Limited idea input to 10 lines with scroll',
       'Save & Another button allows quick addition of multiple ideas',
     ],


### PR DESCRIPTION
## Summary
- Add margin top to Show Archived toggle in empty state
- Bump version to 1.4.4
- Change "labels" to "categories" in changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)